### PR TITLE
Add structop, rename some config env vars.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
-RUST_LOG=actix_web=INFO,estuary=TRACE
+# Environment vars suited for the local development of estuary
+# Make a copy of this file named `.env`.
 
+RUST_LOG=actix_web=INFO,estuary=TRACE
+ESTUARY_BASE_URL=http://localhost:7878
 ESTUARY_INDEX_DIR=_data/index
 ESTUARY_CRATE_DIR=_data/crates
-ESTUARY_API_URL=http://localhost:7878

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "actix-macros"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60f9ba7c4e6df97f3aacb14bb5c0cd7d98a49dcbaed0d7f292912ad9a6a3ed2"
+checksum = "b4ca8ce00b267af8ccebbd647de0d61e0674b6e61185cc7a592ff88772bed655"
 dependencies = [
  "quote",
  "syn",
@@ -306,6 +306,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +497,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +646,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "structopt",
  "tempdir",
 ]
 
@@ -1311,6 +1336,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check 0.9.2",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check 0.9.2",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
 dependencies = [
  "itoa",
  "ryu",
@@ -1676,6 +1725,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +1782,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1941,6 +2029,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,6 +2089,12 @@ name = "vcpkg"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,19 @@ license = "Apache-2.0/MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "3.3"
-actix-files = "0.4"
+actix-web = "3.3.2"
+actix-files = "0.4.1"
 anyhow = "1.0"
-byteorder = "1.3"
-dotenv = "0.15"
-env_logger = "0.8"
-git2 = "0.13"
-log = "0.4"
+byteorder = "1.3.4"
+dotenv = { version = "0.15.0", optional = true }
+env_logger = "0.8.2"
+git2 = "0.13.12"
+log = "0.4.11"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
-sha2 = "0.9"
+sha2 = "0.9.2"
+structopt = "0.3.21"
 
 [dev-dependencies]
-tempdir = "0.3"
-actix-rt = "1.1"
+tempdir = "0.3.7"
+actix-rt = "1.1.1"

--- a/README.md
+++ b/README.md
@@ -38,59 +38,50 @@ such is only appropriate for *internal use*.**
 $ cargo install estuary
 ```
 
-Estuary depends on being able to run `git` on the command-line.
+Support for loading environment variables from a `.env` file (off by default)
+can be added with:
 
+```
+$ cargo install estuary --features dotenv
+```
+
+Estuary depends on being able to run `git` on the command-line.
 
 ## Usage
 
 ### Estuary Server
 
-Estuary relies on environment variables for configuration.
 
-Required:
+For a full list of configuration options, run `estuary --help`.
 
-- `ESTUARY_INDEX_DIR` Directory to store the git repository used to manage the package index.
-- `ESTUARY_CRATE_DIR` Directory path for crate files to be written to.
-- `ESTUARY_API_URL` Public root URL for the Estuary server ex: `http://estuary.example.com` (no trailing slash).
+Estuary allows for configuration to be specified by either flags on the command
+line, or from environment variables.
 
-Optional:
+Required Configuration:
 
-- `ESTUARY_HOST` defaults to `0.0.0.0`.
-- `ESTUARY_PORT` defaults to `7878`.
-- `ESTUARY_DL_URL` defaults to `${ESTUARY_API_URL}/api/v1/crates/{crate}/{version}/download`.
-- `ESTUARY_GIT_BIN` defaults to just `git`, expecting it to be in the `PATH`. 
+- `--base-url`/`ESTUARY_BASE_URL` Public URL for the Estuary server, ex: `http://estuary.example.com`.
+- `--crate-dir`/`ESTUARY_CRATE_DIR` Path to store crate files.
+- `--index-dir`/`ESTUARY_INDEX_DIR` Path to store the git repository (used to manage the package index).
 
-
-When crates are published to Estuary, the `.crate` files are written to
-`${ESTUARY_CRATE_DIR}/{crate}/{version}/{crate}-{version}.crate` which
-aligns with the default value for `ESTUARY_DL_URL`.
-
-
-> If you prefer, you can serve the `.crate` files using a separate web server.
-> For this, you'd set `ESTUARY_DL_URL` to point to that other web server, using
-> the same `{crate}` and `{version}` replacement tokens.
-> 
-> See the [section on `dl`][index format] in the alternate cargo registry docs 
-> for a full list of available tokens cargo can use when building download urls.
-> These other tokens may be useful if you end up moving the crate files into a
-> different directory layout or have URL rewrite rules to deal with.
-
-With your configuration in place, run `estuary` to launch the server.
+> Note: Estuary relies on being able to run `git` on the command line, and
+> expects to be able to find `git` in the `PATH`. If for some reason you're
+> running Estuary in an environment where this is not the case, you should
+> specify a path to the `git` binary with `--git-bin` or `ESTUARY_GIT_BIN`.
 
 
 ### Configuring Cargo
 
-Estuary exposes the package index git repository at the following URL:
+Estuary exposes its package index git repository at the following URL:
 
 ```
-${ESTUARY_API_URL}/git/index
+<base-url>/git/index
 ```
 
 To use Estuary for publishing or installing crates via cargo you need to add
 some configuration. 
 
-For example, if you defined `ESTUARY_API_URL` as `http://estuary.example.com`, you
-would add the following to your `.cargo/config.toml`:
+For example, if you defined your **<base-url>** as `http://estuary.example.com`,
+you would add the following to your `.cargo/config.toml`:
 
 ```toml
 [registries]
@@ -123,7 +114,7 @@ my-cool-package = { version = "1.2.3", registry = "estuary" }
 Binary crates can also be installed using the `--registry` flag:
 
 ```
-$ cargo install --registry estuary my-cool-cli
+$ cargo install --registry estuary my-cool-app
 ```
 
 Environment variables can also be used to configure cargo.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,123 @@
+//! Some of the fields on `Opt` require careful handling currently managed
+//! through getters. In order to restrict direct access to those
+//! getter-accessed fields, we tuck it away in this module.
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+/// Something about the macros used by `structopt` mean the return from
+/// `from_args()` is <unknown> in code editors without a type ascription or some
+/// other
+/// hint. This function provides such a hint.
+pub fn parse_args() -> Opt {
+    Opt::from_args()
+}
+
+#[derive(StructOpt)]
+pub struct Opt {
+    #[structopt(
+        long,
+        env = "ESTUARY_BASE_URL",
+        help = "The public url for the service."
+    )]
+    base_url: String,
+
+    #[structopt(
+        long,
+        parse(from_os_str),
+        env = "ESTUARY_INDEX_DIR",
+        help = "A directory to store the package index git repo."
+    )]
+    pub index_dir: PathBuf,
+
+    #[structopt(
+        long,
+        parse(from_os_str),
+        env = "ESTUARY_CRATE_DIR",
+        help = "A directory to store `.crate` files."
+    )]
+    pub crate_dir: PathBuf,
+
+    #[structopt(
+        long,
+        env = "ESTUARY_DOWNLOAD_URL",
+        help = "The url template cargo will use when downloading crates from the registry. \
+        Defaults to `<base_url>/api/v1/crates/{crate}/{version}/download`."
+    )]
+    download_url: Option<String>,
+
+    #[structopt(long, default_value = "0.0.0.0", env = "ESTUARY_HTTP_HOST")]
+    pub http_host: String,
+
+    #[structopt(long, default_value = "7878", env = "ESTUARY_HTTP_PORT")]
+    pub http_port: u16,
+
+    #[structopt(
+        long,
+        parse(from_os_str),
+        env = "ESTUARY_GIT_BIN",
+        default_value = "git",
+        help = "Path to `git`."
+    )]
+    pub git_bin: PathBuf,
+}
+
+impl Opt {
+    /// Public getter for the `base_url` field.
+    ///
+    /// Mainly this just ensures there are no trailing slashes in there.
+    pub fn base_url(&self) -> &str {
+        self.base_url.trim_end_matches('/')
+    }
+
+    /// Returns the value of the `download_url` field verbatim when set.
+    ///
+    /// When left `download_url` is left unset, the path to the download handler
+    /// is built based on the value of the base url.
+    pub fn download_url(&self) -> String {
+        self.download_url.clone().unwrap_or_else(|| {
+            format!(
+                "{}/api/v1/crates/{{crate}}/{{version}}/download",
+                self.base_url()
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_base_url_trims_trailing_slashes() {
+        let opt = Opt {
+            // weird
+            base_url: "http://example.com/////".to_string(),
+            index_dir: Default::default(),
+            crate_dir: Default::default(),
+            download_url: None,
+            http_host: "".to_string(),
+            http_port: 0,
+            git_bin: Default::default(),
+        };
+
+        assert_eq!("http://example.com", opt.base_url());
+    }
+
+    #[test]
+    fn test_download_url_default() {
+        let opt = Opt {
+            base_url: "http://example.com".to_string(),
+            index_dir: Default::default(),
+            crate_dir: Default::default(),
+            download_url: None,
+            http_host: "".to_string(),
+            http_port: 0,
+            git_bin: Default::default(),
+        };
+
+        assert_eq!(
+            "http://example.com/api/v1/crates/{crate}/{version}/download",
+            opt.download_url()
+        );
+    }
+}

--- a/src/package_index.rs
+++ b/src/package_index.rs
@@ -26,7 +26,6 @@ use git2::Oid;
 use git2::{Repository, RepositoryInitOptions, Signature};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::env;
 use std::fs::OpenOptions;
 use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
@@ -36,16 +35,6 @@ use std::path::{Path, PathBuf};
 pub struct Config {
     pub dl: String,
     pub api: String,
-}
-
-impl Config {
-    pub fn from_env() -> Result<Self> {
-        let api = env::var("ESTUARY_API_URL").context("ESTUARY_API_URL is required")?;
-        let dl = env::var("ESTUARY_DL_URL")
-            .unwrap_or_else(|_| format!("{}/api/v1/crates/{{crate}}/{{version}}/download", api));
-
-        Ok(Self { dl, api })
-    }
 }
 
 /// These records appear, one per line per version, in each crate file.


### PR DESCRIPTION
Some of the config jargon was taken directly from cargo's docs on alt
registries, but could be confusing. The public facing flags and env vars
have been renamed to try and make their purpose more clear.

Ex: the "API URL" is hopefully more clear when named "base url" since it
acts as the prefix for other urls.

Also, while we're adding new deps, I ran a cargo update and specified
patch level versions on the pre-1.0 crates (and others that play fast
and lose with semver).