### PR TITLE
Show whether a crate version has been yanked.

### DIFF
--- a/src/handlers/frontend.rs
+++ b/src/handlers/frontend.rs
@@ -9,7 +9,7 @@ use std::sync::Mutex;
 #[template(path = "landing.html")]
 pub struct LandingTemplate<'a> {
     name: &'a str,
-    packages: Vec<(String, String)>,
+    packages: Vec<(String, String, String)>,
     all: bool,
     limit: usize,
 }
@@ -34,14 +34,22 @@ pub async fn landing(
     let all = query.all.unwrap_or(false);
     let limit = if all { None } else { Some(25) };
 
-    let entries = {
+    let publishes = {
         let index = index.lock().unwrap();
-        index.get_publishes(limit)?
+        let mut results = vec![];
+        for ((pkg, vers), yanked) in index.get_crates()?.drain() {
+            results.push((
+                pkg,
+                vers,
+                String::from(if yanked { "true" } else { "false" }),
+            ));
+        }
+        results
     };
 
     Ok(LandingTemplate {
         name: "Estuary",
-        packages: entries,
+        packages: publishes,
         all,
         limit: limit.unwrap_or(0),
     })

--- a/src/handlers/frontend.rs
+++ b/src/handlers/frontend.rs
@@ -44,6 +44,7 @@ pub async fn landing(
                 String::from(if yanked { "true" } else { "false" }),
             ));
         }
+        results.reverse();
         results
     };
 

--- a/src/handlers/frontend.rs
+++ b/src/handlers/frontend.rs
@@ -37,7 +37,7 @@ pub async fn landing(
     let publishes = {
         let index = index.lock().unwrap();
         let mut results = vec![];
-        for ((pkg, vers), yanked) in index.get_crates()?.drain() {
+        for ((pkg, vers), yanked) in index.get_publishes()?.drain() {
             results.push((
                 pkg,
                 vers,

--- a/src/package_index.rs
+++ b/src/package_index.rs
@@ -346,6 +346,7 @@ impl PackageIndex {
         let reflog = self.repo.reflog("HEAD")?;
         reflog
             .iter()
+            .rev()
             .filter(|entry| {
                 let msg = entry.message().unwrap_or("");
                 msg.contains("publish crate")
@@ -360,15 +361,8 @@ impl PackageIndex {
                     parts.next().unwrap().to_string(),
                     parts.next().unwrap().to_string(),
                 );
-                let yanked = msg.contains("yank crate");
-
-                if let Some(val) = yanked_versions.get(&key) {
-                    if yanked && !*val {
-                        yanked_versions.insert(key, yanked);
-                    }
-                } else {
-                    yanked_versions.insert(key, yanked);
-                }
+                let yanked = msg.contains("commit: yank crate");
+                yanked_versions.insert(key, yanked);
             });
         Ok(yanked_versions)
     }

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1,26 +1,29 @@
 <!doctype html>
 <html lang="en">
+
 <head>
     <title>{{ name }}</title>
 </head>
+
 <body>
-<h1>{{ name }}</h1>
-<h3>
+    <h1>{{ name }}</h1>
+    <h3>
+        {% if !all %}
+        {{ limit }} Most Recent Publishes:
+        {% else %}
+        All Publishes:
+        {% endif %}
+    </h3>
+    <ul>
+        {% for (pkg, vers, yanked) in packages %}
+        <li>{{ pkg }} {{ vers }} {% if yanked == "true" %}(yanked){% endif %}</li>
+        {% endfor %}
+    </ul>
     {% if !all %}
-    {{ limit }} Most Recent Publishes:
-    {% else %}
-    All Publishes:
+    <p>
+        <a href="?all=true">Show All Publishes</a>
+    </p>
     {% endif %}
-</h3>
-<ul>
-    {% for (pkg, vers) in packages %}
-    <li>{{ pkg }} {{ vers }}</li>
-    {% endfor %}
-</ul>
-{% if !all %}
-<p>
-    <a href="?all=true">Show All Publishes</a>
-</p>
-{% endif %}
 </body>
+
 </html>


### PR DESCRIPTION
The fact the crate data is harvested from the git reflog influences how I approached this. We're basically iterating over log lines, but since a single package & version pair can have multiple reflog lines, I needed a way to keep track of what package/version pairs I've already seen, and whether or not they have been yanked.

`HashMap<(String, String), bool>` seemed like a sensible choice for data structure here for fast lookups & duplicate elimination. The `get_publishes` function is only responsible for generating the tell-tale data structure. The logic to "massage" that data into display format is handled in `frontend::landing`. 