### PR TITLE
Remove `anyhow` adopt `thiserror`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,12 +315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
-
-[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,7 +709,6 @@ dependencies = [
  "actix-files",
  "actix-rt",
  "actix-web",
- "anyhow",
  "askama",
  "askama_actix",
  "byteorder",
@@ -728,6 +721,7 @@ dependencies = [
  "sha2",
  "structopt",
  "tempdir",
+ "thiserror",
 ]
 
 [[package]]
@@ -1939,18 +1933,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ actix-web = "3.3.2"
 actix-files = "0.4.1"
 askama = { version = "0.10.5", features = ["with-actix-web"] }
 askama_actix = "0.11.1"
-anyhow = "1.0"
 byteorder = "1.3.4"
 dotenv = { version = "0.15.0", optional = true }
 env_logger = "0.8.2"
@@ -27,6 +26,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 sha2 = "0.9.2"
 structopt = "0.3.21"
+thiserror = "1.0.23"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/src/handlers/frontend.rs
+++ b/src/handlers/frontend.rs
@@ -1,9 +1,11 @@
-use crate::errors::GitResult;
+use crate::errors::EstuaryError;
 use crate::package_index::PackageIndex;
 use actix_web::{get, web, HttpRequest};
 use askama::Template;
 use serde::Deserialize;
 use std::sync::Mutex;
+
+type Result<T> = std::result::Result<T, EstuaryError>;
 
 #[derive(Template)]
 #[template(path = "landing.html")]
@@ -30,7 +32,7 @@ pub struct Query {
 pub async fn landing(
     query: web::Query<Query>,
     index: web::Data<Mutex<PackageIndex>>,
-) -> GitResult<LandingTemplate<'static>> {
+) -> Result<LandingTemplate<'static>> {
     let all = query.all.unwrap_or(false);
     let limit = if all { None } else { Some(25) };
 

--- a/src/handlers/registry.rs
+++ b/src/handlers/registry.rs
@@ -19,12 +19,11 @@
 //!   (result limit - default 10, max 100).
 //! - [x] Login `/me` (this one lives in the frontend module).
 
-use crate::errors::ApiResult;
+use crate::errors::ApiError;
 use crate::package_index::{Dependency, PackageIndex, PackageVersion};
 use crate::Settings;
 use actix_files as fs;
 use actix_web::{delete, get, put, web, HttpResponse};
-use anyhow::Context;
 use byteorder::{LittleEndian, ReadBytesExt};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -32,7 +31,7 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-pub type ApiResponse = ApiResult<HttpResponse>;
+pub type ApiResponse = Result<HttpResponse, ApiError>;
 
 #[derive(Deserialize)]
 pub struct Crate {
@@ -91,8 +90,7 @@ pub async fn publish(
         &pkg_version.name,
         &pkg_version.vers,
         crate_file_bytes.as_ref(),
-    )
-    .context("Failed to store crate file.")?;
+    )?;
     Ok(HttpResponse::Ok().json(json!({
         // Optional object of warnings to display to the user.
         "warnings": {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
+use crate::errors::EstuaryError;
 use actix_web::{middleware, web, App, HttpServer};
-use anyhow::Result;
 use package_index::{Config, PackageIndex};
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -28,7 +28,7 @@ pub struct Settings {
 
 #[cfg(not(tarpaulin_include))]
 #[actix_web::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), EstuaryError> {
     #[cfg(feature = "dotenv")]
     dotenv::dotenv().ok();
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -13,7 +13,7 @@ pub fn store_crate_file<P: AsRef<Path>>(
     name: &str,
     vers: &str,
     content: &[u8],
-) -> anyhow::Result<()> {
+) -> std::io::Result<()> {
     let fp = get_crate_file_path(root.as_ref(), name, vers);
     fs::create_dir_all(fp.parent().unwrap())?;
 


### PR DESCRIPTION
The motivation for this change is mainly to do with the fact `thiserror`
lets us chain errors together without boxing or otherwise losing the
typing.

When generating HTTP responses for errors, we need to know the types of
errors we're handling. Anyhow sort of sets us up to need to downcast
to get the type information back whereas thiserror retains the types.