### PR TITLE
Crate detail, crate version list.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,7 @@ dependencies = [
  "env_logger",
  "git2",
  "log",
+ "semver 0.11.0",
  "serde",
  "serde_json",
  "sha2",
@@ -1386,6 +1387,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "pin-project"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,7 +1664,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -1675,7 +1685,17 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
+ "serde",
 ]
 
 [[package]]
@@ -1683,6 +1703,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -2141,6 +2170,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ dotenv = { version = "0.15.0", optional = true }
 env_logger = "0.8.2"
 git2 = "0.13.12"
 log = "0.4.11"
+semver = { version = "0.11.0", features = ["serde"] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 sha2 = "0.9.2"

--- a/Development.md
+++ b/Development.md
@@ -1,5 +1,12 @@
 # Dev Workflow Notes
 
+
+How to get the test crate published quickly:
+
+```
+curl -X PUT  http://localhost:7878/api/v1/crates/new --data-binary "@test_data/publish-my-crate-body"
+```
+
 ## Running the Procfile
 
 > While the `git daemon` usage has been removed from the project (Estuary is now

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -56,6 +56,10 @@ pub enum EstuaryError {
     PackageIndex(#[from] PackageIndexError),
     #[error("Blocking task canceled")]
     BlockingTaskCanceled,
+    #[error("Not Found")]
+    NotFound,
+    #[error("Invalid Version: `{0}`")]
+    InvalidVersion(#[from] semver::SemVerError),
 }
 
 impl<T> From<BlockingError<T>> for EstuaryError
@@ -72,7 +76,10 @@ where
 
 impl ResponseError for EstuaryError {
     fn status_code(&self) -> StatusCode {
-        StatusCode::INTERNAL_SERVER_ERROR
+        match self {
+            EstuaryError::NotFound => StatusCode::NOT_FOUND,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        }
     }
 
     fn error_response(&self) -> HttpResponse {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -17,5 +17,11 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             .service(registry::download),
     )
     .service(frontend::login)
-    .service(frontend::landing);
+    .service(frontend::landing)
+    .service(
+        web::scope("/crates/{crate_name}")
+            .route("/versions", web::get().to(frontend::version_list))
+            .route("/{version}", web::get().to(frontend::crate_detail))
+            .route("", web::get().to(frontend::crate_detail)),
+    );
 }

--- a/src/handlers/frontend.rs
+++ b/src/handlers/frontend.rs
@@ -1,5 +1,5 @@
-use crate::errors::EstuaryError;
-use crate::package_index::PackageIndex;
+use crate::errors::{EstuaryError, PackageIndexError};
+use crate::package_index::{Dependency, DependencyKind, PackageIndex, PackageVersion};
 use actix_web::{get, web, HttpRequest};
 use askama::Template;
 use serde::Deserialize;
@@ -10,7 +10,7 @@ type Result<T> = std::result::Result<T, EstuaryError>;
 #[derive(Template)]
 #[template(path = "landing.html")]
 pub struct LandingTemplate<'a> {
-    name: &'a str,
+    title: &'a str,
     packages: Vec<(String, String)>,
     all: bool,
     limit: usize,
@@ -19,8 +19,18 @@ pub struct LandingTemplate<'a> {
 #[derive(Template)]
 #[template(path = "login.html")]
 pub struct LoginTemplate<'a> {
-    name: &'a str,
+    title: &'a str,
     token: &'a str,
+}
+
+#[derive(Template)]
+#[template(path = "crate_detail.html")]
+pub struct CrateDetailTemplate {
+    title: String,
+    pkg: PackageVersion,
+    dev_deps: Vec<Dependency>,
+    non_dev_deps: Vec<Dependency>,
+    releases: Vec<PackageVersion>,
 }
 
 #[derive(Deserialize)]
@@ -42,7 +52,7 @@ pub async fn landing(
     };
 
     Ok(LandingTemplate {
-        name: "Estuary",
+        title: "Welcome",
         packages: entries,
         all,
         limit: limit.unwrap_or(0),
@@ -52,14 +62,105 @@ pub async fn landing(
 #[get("/me")]
 pub async fn login(_req: HttpRequest) -> LoginTemplate<'static> {
     LoginTemplate {
-        name: "Estuary",
+        title: "Login",
         token: "0000", // TODO: implement proper auth
+    }
+}
+
+#[derive(Template)]
+#[template(path = "crate_version_list.html")]
+pub struct CrateVersionListTemplate {
+    crate_name: String,
+    releases: Vec<PackageVersion>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct CrateVersionListPath {
+    crate_name: String,
+}
+
+pub async fn version_list(
+    path: web::Path<CrateVersionListPath>,
+    index: web::Data<Mutex<PackageIndex>>,
+) -> Result<CrateVersionListTemplate> {
+    let index = index.lock().unwrap();
+    let releases = index
+        .get_package_versions(&path.crate_name)
+        .map_err(|e| match e {
+            PackageIndexError::IO(e @ std::io::Error { .. })
+                if e.kind() == std::io::ErrorKind::NotFound =>
+            {
+                EstuaryError::NotFound
+            }
+            _ => e.into(),
+        })?;
+
+    Ok(CrateVersionListTemplate {
+        crate_name: path.crate_name.clone(),
+        releases,
+    })
+}
+
+#[derive(Deserialize, Debug)]
+pub struct CrateDetailPath {
+    crate_name: String,
+    /// When version is None, we'll serve the highest available version.
+    version: Option<semver::Version>,
+}
+
+pub async fn crate_detail(
+    path: web::Path<CrateDetailPath>,
+    index: web::Data<Mutex<PackageIndex>>,
+) -> Result<CrateDetailTemplate> {
+    // 404 if:
+    // - the crate isn't in the index
+    // - the crate version doesn't exist
+    // - the requested version isn't a valid version string
+
+    let index = index.lock().unwrap();
+
+    let all_releases = index
+        .get_package_versions(&path.crate_name)
+        .map_err(|e| match e {
+            PackageIndexError::IO(e @ std::io::Error { .. })
+                if e.kind() == std::io::ErrorKind::NotFound =>
+            {
+                EstuaryError::NotFound
+            }
+            _ => e.into(),
+        })?;
+
+    let pkg = match &path.version {
+        Some(vers) => all_releases.iter().find(|p| &p.vers == vers),
+        None => all_releases.iter().max_by_key(|p| &p.vers),
+    }
+    .cloned();
+
+    match pkg {
+        Some(pkg) => {
+            let (dev_deps, non_dev_deps) = pkg
+                .deps
+                .iter()
+                .cloned()
+                .partition(|dep| dep.kind == DependencyKind::Dev);
+
+            Ok(CrateDetailTemplate {
+                title: format!("{} v{}", pkg.name, pkg.vers),
+                pkg,
+                dev_deps,
+                non_dev_deps,
+                // Think about showing the highest N instead of all
+                releases: all_releases,
+            })
+        }
+        None => return Err(EstuaryError::NotFound),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::test_helpers;
+    use crate::test_helpers::MY_CRATE_0_1_0;
     use actix_web::http::StatusCode;
     use actix_web::{test, App};
 
@@ -97,5 +198,129 @@ mod tests {
         let req = test::TestRequest::get().uri("/me").to_request();
         let resp = test::call_service(&mut app, req).await;
         assert_eq!(StatusCode::OK, resp.status());
+    }
+
+    #[actix_rt::test]
+    async fn test_detail_existing_crate_no_version_is_ok() {
+        let data_root = test_helpers::get_data_root();
+        let settings = test_helpers::get_test_settings(&data_root.path());
+        let package_index = test_helpers::get_test_package_index(&settings.index_dir);
+
+        let mut app = test::init_service(
+            App::new()
+                .app_data(settings.clone())
+                .app_data(package_index.clone())
+                .configure(crate::handlers::configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::put()
+            .uri("/api/v1/crates/new")
+            .set_payload(MY_CRATE_0_1_0)
+            .to_request();
+
+        let _: serde_json::Value = test::read_response_json(&mut app, req).await;
+
+        let req = test::TestRequest::get()
+            .uri("/crates/my-crate")
+            .to_request();
+
+        let resp = test::call_service(&mut app, req).await;
+        assert_eq!(StatusCode::OK, resp.status());
+    }
+
+    #[actix_rt::test]
+    async fn test_detail_nonexistent_crate_is_not_found() {
+        let data_root = test_helpers::get_data_root();
+        let settings = test_helpers::get_test_settings(&data_root.path());
+        let package_index = test_helpers::get_test_package_index(&settings.index_dir);
+
+        let mut app = test::init_service(
+            App::new()
+                .app_data(settings.clone())
+                .app_data(package_index.clone())
+                .configure(crate::handlers::configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/crates/non-existent/0.1.0")
+            .to_request();
+
+        let resp = test::call_service(&mut app, req).await;
+        assert_eq!(StatusCode::NOT_FOUND, resp.status());
+    }
+
+    #[actix_rt::test]
+    async fn test_detail_nonexistent_crate_no_version_is_not_found() {
+        let data_root = test_helpers::get_data_root();
+        let settings = test_helpers::get_test_settings(&data_root.path());
+        let package_index = test_helpers::get_test_package_index(&settings.index_dir);
+
+        let mut app = test::init_service(
+            App::new()
+                .app_data(settings.clone())
+                .app_data(package_index.clone())
+                .configure(crate::handlers::configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/crates/non-existent")
+            .to_request();
+
+        let resp = test::call_service(&mut app, req).await;
+        assert_eq!(StatusCode::NOT_FOUND, resp.status());
+    }
+
+    #[actix_rt::test]
+    async fn test_version_list_existing_crate_is_ok() {
+        let data_root = test_helpers::get_data_root();
+        let settings = test_helpers::get_test_settings(&data_root.path());
+        let package_index = test_helpers::get_test_package_index(&settings.index_dir);
+
+        let mut app = test::init_service(
+            App::new()
+                .app_data(settings.clone())
+                .app_data(package_index.clone())
+                .configure(crate::handlers::configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::put()
+            .uri("/api/v1/crates/new")
+            .set_payload(MY_CRATE_0_1_0)
+            .to_request();
+
+        let _: serde_json::Value = test::read_response_json(&mut app, req).await;
+
+        let req = test::TestRequest::get()
+            .uri("/crates/my-crate/versions")
+            .to_request();
+
+        let resp = test::call_service(&mut app, req).await;
+        assert_eq!(StatusCode::OK, resp.status());
+    }
+
+    #[actix_rt::test]
+    async fn test_version_list_nonexistent_crate_is_not_found() {
+        let data_root = test_helpers::get_data_root();
+        let settings = test_helpers::get_test_settings(&data_root.path());
+        let package_index = test_helpers::get_test_package_index(&settings.index_dir);
+
+        let mut app = test::init_service(
+            App::new()
+                .app_data(settings.clone())
+                .app_data(package_index.clone())
+                .configure(crate::handlers::configure_routes),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/crates/non-existent/versions")
+            .to_request();
+
+        let resp = test::call_service(&mut app, req).await;
+        assert_eq!(StatusCode::NOT_FOUND, resp.status());
     }
 }

--- a/src/handlers/registry.rs
+++ b/src/handlers/registry.rs
@@ -36,7 +36,7 @@ pub type ApiResponse = Result<HttpResponse, ApiError>;
 #[derive(Deserialize)]
 pub struct Crate {
     crate_name: String,
-    version: String,
+    version: semver::Version,
 }
 
 /// Data supplied by `cargo` during the publishing of a crate.
@@ -46,7 +46,7 @@ pub struct Crate {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PartialPackageVersion {
     name: String,
-    vers: String,
+    vers: semver::Version,
     deps: Vec<Dependency>,
     features: HashMap<String, Vec<String>>,
     links: Option<String>,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2,7 +2,7 @@ use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-pub fn get_crate_file_path<P: AsRef<Path>>(root: P, name: &str, vers: &str) -> PathBuf {
+pub fn get_crate_file_path<P: AsRef<Path>>(root: P, name: &str, vers: &semver::Version) -> PathBuf {
     let dir = root.as_ref().join(name);
     dir.join(&format!("{}-{}.crate", name, vers))
 }
@@ -11,7 +11,7 @@ pub fn get_crate_file_path<P: AsRef<Path>>(root: P, name: &str, vers: &str) -> P
 pub fn store_crate_file<P: AsRef<Path>>(
     root: P,
     name: &str,
-    vers: &str,
+    vers: &semver::Version,
     content: &[u8],
 ) -> std::io::Result<()> {
     let fp = get_crate_file_path(root.as_ref(), name, vers);

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>{% block title %}{{ title }} :: Estuary{% endblock %}</title>
+        <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet" />
+        {% block head %}{% endblock %}
+    </head>
+    <body>
+        <div class="container mx-auto">
+            <div class="flex flex-row">
+                <article id="content" class="p-4 w-2/3 flex-grow">
+                    {%- block content %}{% endblock -%}
+                </article>
+                <section id="sidebar" class="p-4 w-1/3 flex-none">
+                    {%- block sidebar %}{% endblock -%}
+                </section>
+            </div>
+            <footer class="text-gray-700 text-xs text-center border-t mt-8 p-4">
+                <a href="/">Estuary v{{ env!("CARGO_PKG_VERSION") }}</a>
+            </footer>
+        </div>
+
+    </body>
+</html>

--- a/templates/crate_detail.html
+++ b/templates/crate_detail.html
@@ -1,0 +1,68 @@
+{% extends "base.html" %}
+{% block content %}
+<header>
+    <span class="text-2xl text-gray-900">{{ pkg.name }}</span>
+    <span class="text-gray-600">{{ pkg.vers }}</span>
+</header>
+<div class="my-6">
+    {%- if pkg.yanked -%}
+    <p>
+        This version of the crate has been yanked, but
+        <a href="/crates/{{ pkg.name }}/versions">other versions</a> may be
+        available.
+    </p>
+    {%- else -%}
+    <!-- It would be grand if we had a readme to display here, but alas... -->
+    {%- endif -%}
+</div>
+{% endblock %}
+
+{% block sidebar %}
+<dl>
+    <div class="rounded border-gray-300 mt-1 border p-2">
+        <dt class="text-md">Dependencies</dt>
+        <dd>
+            <ul class="list-disc list-inside text-sm">
+                {% for dep in non_dev_deps %}
+                <li>
+                    {{ dep.name }} {{ dep.req }}
+                    {% if dep.optional -%}
+                    <em>optional</em>
+                    {%- endif %}
+                </li>
+                {% endfor %}
+            </ul>
+        </dd>
+    </div>
+    <div class="rounded border-gray-300 mt-1 border p-2">
+        <dt class="text-md">Dev Dependencies</dt>
+        <dd>
+            <ul class="list-disc list-inside text-sm">
+                {% for dep in dev_deps %}
+                <li>
+                    {{ dep.name }} {{ dep.req }}
+                    {% if dep.optional -%}
+                    <em>optional</em>
+                    {%- endif %}
+                </li>
+                {% endfor %}
+            </ul>
+        </dd>
+    </div>
+    <div class="rounded border-gray-300 mt-1 border p-2">
+        <dt>Versions</dt>
+        <dd>
+            <ul class="list-disc list-inside text-sm">
+                {% for release in releases %}
+                <li>
+                    <a class="underline" href="/crates/{{ release.name }}/{{ release.vers }}">{{ release.vers }}</a>
+                    {% if release.yanked -%}
+                    (<em>yanked</em>)
+                    {%- endif %}
+                </li>
+                {% endfor %}
+            </ul>
+        </dd>
+    </div>
+</dl>
+{% endblock %}

--- a/templates/crate_version_list.html
+++ b/templates/crate_version_list.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}{{ crate_name}} :: All Versions :: Estuary{% endblock %}
+{% block content %}
+<header>
+    <span class="text-2xl text-gray-900">{{ crate_name }}</span>
+    <span class="text-gray-600">All Versions</span>
+</header>
+<div class="my-6">
+    <ul class="list-disc list-inside text-sm">
+        {% for release in releases %}
+        <li>
+            <a class="underline" href="/crates/{{ release.name }}/{{ release.vers }}">{{ release.vers }}</a>
+            {% if release.yanked -%}
+            (<em>yanked</em>)
+            {%- endif %}
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+{% endblock %}

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1,10 +1,5 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <title>{{ name }}</title>
-</head>
-<body>
-<h1>{{ name }}</h1>
+{% extends "base.html" %}
+{% block content %}
 <h3>
     {% if !all %}
     {{ limit }} Most Recent Publishes:
@@ -19,8 +14,7 @@
 </ul>
 {% if !all %}
 <p>
-    <a href="?all=true">Show All Publishes</a>
+    <a class="underline" href="?all=true">Show All Publishes</a>
 </p>
 {% endif %}
-</body>
-</html>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,15 +1,9 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <title>{{ name }}</title>
-</head>
-<body>
-<h1>{{ name }}</h1>
+{% extends "base.html" %}
+{% block content %}
 <dl>
     <dt>Your token is:</dt>
     <dd>
         <pre>{{ token }}</pre>
     </dd>
 </dl>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
New handlers, templates and supporting code to render pages for crates.

The crate detail page will default to the highest version if a specific
version isn't named explicitly.

Templates for the site have been reorganized to extend a common base.

Currently, tailwindcss is being sourced from a cdn which is not ideal.
A js project will be added so we can tree-shake the styles properly
before the next release.

Crate detail pages are fashioned after those on crates.io, but sadly the
index data we're keeping does not include the readme for each release.
We'll need some extra storage of our own if we want to display more than
the dependencies. For now, the page stays roughly bare.