### PR TITLE
Display a list of crates on the landing page.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,7 @@ dependencies = [
  "dotenv",
  "env_logger",
  "git2",
+ "glob",
  "log",
  "semver 0.11.0",
  "serde",
@@ -914,6 +915,12 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1.0"
 sha2 = "0.9.2"
 structopt = "0.3.21"
 thiserror = "1.0.23"
+glob = "0.3.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,17 @@
         "purgecss": "^3.1.3"
       }
     },
+    "@tailwindcss/typography": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.4.0.tgz",
+      "integrity": "sha512-3BfOYT5MYNEq81Ism3L2qu/HRP2Q5vWqZtZRQqQrthHuaTK9qpuPfbMT5WATjAM5J1OePKBaI5pLoX4S1JGNMQ==",
+      "requires": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -403,11 +414,31 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
+    "lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
     "lodash.toarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
       "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   "devDependencies": {
     "cross-env": "^7.0.3",
     "tailwindcss-cli": "^0.1.2"
+  },
+  "dependencies": {
+    "@tailwindcss/typography": "^0.4.0"
   }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -44,6 +44,10 @@ pub enum PackageIndexError {
     Publish(String),
     #[error("Invalid package name: `{0}`")]
     InvalidPackageName(String),
+    #[error("Glob failed: `{0}`")]
+    Glob(#[from] glob::GlobError),
+    #[error("Glob pattern failed: `{0}`")]
+    GlobPattern(#[from] glob::PatternError),
 }
 
 #[derive(Debug, Error)]

--- a/styles/main.dist.css
+++ b/styles/main.dist.css
@@ -1,3 +1,8 @@
+/**
+This is the "source" for our styles. To build the dist (referenced by the main
+site), run `npm install` and `npm run build` from the repo root.
+*/
+
 /*! modern-normalize v1.0.0 | MIT License | https://github.com/sindresorhus/modern-normalize */
 
 /*
@@ -550,6 +555,353 @@ video {
   }
 }
 
+.prose {
+  color: #374151;
+  max-width: 65ch;
+}
+
+.prose a {
+  color: #111827;
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+.prose strong {
+  color: #111827;
+  font-weight: 600;
+}
+
+.prose ol[type="A"] {
+  --list-counter-style: upper-alpha;
+}
+
+.prose ol[type="a"] {
+  --list-counter-style: lower-alpha;
+}
+
+.prose ol[type="I"] {
+  --list-counter-style: upper-roman;
+}
+
+.prose ol[type="i"] {
+  --list-counter-style: lower-roman;
+}
+
+.prose ol[type="1"] {
+  --list-counter-style: decimal;
+}
+
+.prose ol > li {
+  position: relative;
+  padding-left: 1.75em;
+}
+
+.prose ol > li::before {
+  content: counter(list-item, var(--list-counter-style, decimal)) ".";
+  position: absolute;
+  font-weight: 400;
+  color: #6b7280;
+  left: 0;
+}
+
+.prose ul > li {
+  position: relative;
+  padding-left: 1.75em;
+}
+
+.prose ul > li::before {
+  content: "";
+  position: absolute;
+  background-color: #d1d5db;
+  border-radius: 50%;
+  width: 0.375em;
+  height: 0.375em;
+  top: calc(0.875em - 0.1875em);
+  left: 0.25em;
+}
+
+.prose hr {
+  border-color: #e5e7eb;
+  border-top-width: 1px;
+  margin-top: 3em;
+  margin-bottom: 3em;
+}
+
+.prose blockquote {
+  font-weight: 500;
+  font-style: italic;
+  color: #111827;
+  border-left-width: 0.25rem;
+  border-left-color: #e5e7eb;
+  quotes: "\201C""\201D""\2018""\2019";
+  margin-top: 1.6em;
+  margin-bottom: 1.6em;
+  padding-left: 1em;
+}
+
+.prose blockquote p:first-of-type::before {
+  content: open-quote;
+}
+
+.prose blockquote p:last-of-type::after {
+  content: close-quote;
+}
+
+.prose h1 {
+  color: #111827;
+  font-weight: 800;
+  font-size: 2.25em;
+  margin-top: 0;
+  margin-bottom: 0.8888889em;
+  line-height: 1.1111111;
+}
+
+.prose h2 {
+  color: #111827;
+  font-weight: 700;
+  font-size: 1.5em;
+  margin-top: 2em;
+  margin-bottom: 1em;
+  line-height: 1.3333333;
+}
+
+.prose h3 {
+  color: #111827;
+  font-weight: 600;
+  font-size: 1.25em;
+  margin-top: 1.6em;
+  margin-bottom: 0.6em;
+  line-height: 1.6;
+}
+
+.prose h4 {
+  color: #111827;
+  font-weight: 600;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  line-height: 1.5;
+}
+
+.prose figure figcaption {
+  color: #6b7280;
+  font-size: 0.875em;
+  line-height: 1.4285714;
+  margin-top: 0.8571429em;
+}
+
+.prose code {
+  color: #111827;
+  font-weight: 600;
+  font-size: 0.875em;
+}
+
+.prose code::before {
+  content: "`";
+}
+
+.prose code::after {
+  content: "`";
+}
+
+.prose a code {
+  color: #111827;
+}
+
+.prose pre {
+  color: #e5e7eb;
+  background-color: #1f2937;
+  overflow-x: auto;
+  font-size: 0.875em;
+  line-height: 1.7142857;
+  margin-top: 1.7142857em;
+  margin-bottom: 1.7142857em;
+  border-radius: 0.375rem;
+  padding-top: 0.8571429em;
+  padding-right: 1.1428571em;
+  padding-bottom: 0.8571429em;
+  padding-left: 1.1428571em;
+}
+
+.prose pre code {
+  background-color: transparent;
+  border-width: 0;
+  border-radius: 0;
+  padding: 0;
+  font-weight: 400;
+  color: inherit;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+}
+
+.prose pre code::before {
+  content: none;
+}
+
+.prose pre code::after {
+  content: none;
+}
+
+.prose table {
+  width: 100%;
+  table-layout: auto;
+  text-align: left;
+  margin-top: 2em;
+  margin-bottom: 2em;
+  font-size: 0.875em;
+  line-height: 1.7142857;
+}
+
+.prose thead {
+  color: #111827;
+  font-weight: 600;
+  border-bottom-width: 1px;
+  border-bottom-color: #d1d5db;
+}
+
+.prose thead th {
+  vertical-align: bottom;
+  padding-right: 0.5714286em;
+  padding-bottom: 0.5714286em;
+  padding-left: 0.5714286em;
+}
+
+.prose tbody tr {
+  border-bottom-width: 1px;
+  border-bottom-color: #e5e7eb;
+}
+
+.prose tbody tr:last-child {
+  border-bottom-width: 0;
+}
+
+.prose tbody td {
+  vertical-align: top;
+  padding-top: 0.5714286em;
+  padding-right: 0.5714286em;
+  padding-bottom: 0.5714286em;
+  padding-left: 0.5714286em;
+}
+
+.prose {
+  font-size: 1rem;
+  line-height: 1.75;
+}
+
+.prose p {
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
+
+.prose img {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose video {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose figure {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose figure > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.prose h2 code {
+  font-size: 0.875em;
+}
+
+.prose h3 code {
+  font-size: 0.9em;
+}
+
+.prose ol {
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
+
+.prose ul {
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
+
+.prose li {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.prose > ul > li p {
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+}
+
+.prose > ul > li > *:first-child {
+  margin-top: 1.25em;
+}
+
+.prose > ul > li > *:last-child {
+  margin-bottom: 1.25em;
+}
+
+.prose > ol > li > *:first-child {
+  margin-top: 1.25em;
+}
+
+.prose > ol > li > *:last-child {
+  margin-bottom: 1.25em;
+}
+
+.prose ul ul, .prose ul ol, .prose ol ul, .prose ol ol {
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+}
+
+.prose hr + * {
+  margin-top: 0;
+}
+
+.prose h2 + * {
+  margin-top: 0;
+}
+
+.prose h3 + * {
+  margin-top: 0;
+}
+
+.prose h4 + * {
+  margin-top: 0;
+}
+
+.prose thead th:first-child {
+  padding-left: 0;
+}
+
+.prose thead th:last-child {
+  padding-right: 0;
+}
+
+.prose tbody td:first-child {
+  padding-left: 0;
+}
+
+.prose tbody td:last-child {
+  padding-right: 0;
+}
+
+.prose > :first-child {
+  margin-top: 0;
+}
+
+.prose > :last-child {
+  margin-bottom: 0;
+}
+
 /* custom components */
 
 /* end: custom components */
@@ -616,10 +968,6 @@ video {
 
 .list-inside {
   list-style-position: inside;
-}
-
-.list-disc {
-  list-style-type: disc;
 }
 
 .my-6 {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,5 +11,7 @@ module.exports = {
   variants: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+      require('@tailwindcss/typography'),
+  ],
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,10 +8,10 @@
     <body>
         <div class="container mx-auto">
             <div class="flex flex-row">
-                <article id="content" class="p-4 w-2/3 flex-grow">
+                <article id="content" class="p-4 w-2/3 flex-grow prose">
                     {%- block content %}{% endblock -%}
                 </article>
-                <section id="sidebar" class="p-4 w-1/3 flex-none">
+                <section id="sidebar" class="p-4 w-1/3 flex-none prose">
                     {%- block sidebar %}{% endblock -%}
                 </section>
             </div>

--- a/templates/crate_detail.html
+++ b/templates/crate_detail.html
@@ -22,7 +22,7 @@
     <div class="rounded border-gray-300 mt-1 border p-2">
         <dt class="text-md">Dependencies</dt>
         <dd>
-            <ul class="list-disc list-inside text-sm">
+            <ul class="list-inside text-sm">
                 {% for dep in non_dev_deps %}
                 <li>
                     {{ dep.name }} {{ dep.req }}
@@ -37,7 +37,7 @@
     <div class="rounded border-gray-300 mt-1 border p-2">
         <dt class="text-md">Dev Dependencies</dt>
         <dd>
-            <ul class="list-disc list-inside text-sm">
+            <ul class="list-inside text-sm">
                 {% for dep in dev_deps %}
                 <li>
                     {{ dep.name }} {{ dep.req }}
@@ -52,7 +52,7 @@
     <div class="rounded border-gray-300 mt-1 border p-2">
         <dt>Versions</dt>
         <dd>
-            <ul class="list-disc list-inside text-sm">
+            <ul class="list-inside text-sm">
                 {% for release in releases %}
                 <li>
                     <a class="underline" href="/crates/{{ release.name }}/{{ release.vers }}">{{ release.vers }}</a>

--- a/templates/crate_version_list.html
+++ b/templates/crate_version_list.html
@@ -6,7 +6,7 @@
     <span class="text-gray-600">All Versions</span>
 </header>
 <div class="my-6">
-    <ul class="list-disc list-inside text-sm">
+    <ul class="list-inside text-sm">
         {% for release in releases %}
         <li>
             <a class="underline" href="/crates/{{ release.name }}/{{ release.vers }}">{{ release.vers }}</a>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1,20 +1,9 @@
 {% extends "base.html" %}
 {% block content %}
-<h3>
-    {% if !all %}
-    {{ limit }} Most Recent Publishes:
-    {% else %}
-    All Publishes:
-    {% endif %}
-</h3>
+<header><span class="text-2xl text-gray-900">Crates</span></header>
 <ul>
-    {% for (pkg, vers) in packages %}
-    <li>{{ pkg }} {{ vers }}</li>
+    {% for pkg in packages %}
+    <li><a class="underline" href="/crates/{{pkg}}">{{ pkg }}</a></li>
     {% endfor %}
 </ul>
-{% if !all %}
-<p>
-    <a class="underline" href="?all=true">Show All Publishes</a>
-</p>
-{% endif %}
 {% endblock %}


### PR DESCRIPTION
This replaces the old git reflog content with a list of crate names
linked to their crate detail pages (latest version).

We will absolutely want to get pagination back into this (currently
we're dumping out the full list) but I think we should wait until we've
got a database in place. A database will allow us to show N most
recently uploaded/modified crates in a much more practical way.

The crate list is built using a series of globs. This was out of
laziness on my part. I think we should be able to write a better
performing implementation without adding an extra dependency given a
little time and focus.