### PR TITLE
Add search endpoint.

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -14,7 +14,8 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             .service(registry::publish)
             .service(registry::yank)
             .service(registry::unyank)
-            .service(registry::download),
+            .service(registry::download)
+            .service(registry::search),
     )
     .service(frontend::styles)
     .service(frontend::login)


### PR DESCRIPTION
This implements the `GET /api/v1/crates` which allows `cargo search` to
work.

This search implementation is very naive, and will be improved once we
have a database in place as our primary source for package info. In the
future the file system and git log will no longer be needed to respond
to requests like this, but for now these are the primary sources.

Fixes #23.