### PR TITLE
Added the simplest option for API Key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "estuary"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "actix-files",
  "actix-rt 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "estuary"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Owen Nelson <onelson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "An alternative cargo registry suitable for *small-scale* crate publishing and distribution."
 repository = "https://github.com/onelson/estuary"
 homepage = "https://github.com/onelson/estuary"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,8 +60,13 @@ pub struct Opt {
     )]
     pub git_bin: PathBuf,
 
-    #[structopt(long, env = "ESTUARY_PUBLISH_KEY")]
-    pub publish_key: Option<String>
+    #[structopt(
+        long = "PUBLISH-KEY",
+        env = "ESTUARY_PUBLISH_KEY",
+        default_value = "00000000-0000-0000-0000-000000000000",
+        help = "The key to use when publishing crates."
+    )]
+    pub publish_key: String
 }
 
 impl Opt {

--- a/src/handlers/frontend.rs
+++ b/src/handlers/frontend.rs
@@ -1,5 +1,6 @@
 use crate::errors::{EstuaryError, PackageIndexError};
 use crate::package_index::{Dependency, DependencyKind, PackageIndex, PackageVersion};
+use crate::Settings;
 use actix_web::{get, web, HttpRequest, HttpResponse};
 use askama::Template;
 use serde::Deserialize;
@@ -30,7 +31,7 @@ pub struct LandingTemplate<'a> {
 #[template(path = "login.html")]
 pub struct LoginTemplate<'a> {
     title: &'a str,
-    token: &'a str,
+    token: String,
 }
 
 #[derive(Template)]
@@ -56,12 +57,13 @@ pub async fn landing(index: web::Data<Mutex<PackageIndex>>) -> Result<LandingTem
 }
 
 #[get("/me")]
-pub async fn login(req: HttpRequest) -> Result<LoginTemplate<'static>> {
+pub async fn login(settings: web::Data<Settings>, req: HttpRequest) -> Result<LoginTemplate<'static>> {
     info!("{:?}", req);
 
+    // TODO: implement proper auth (now it's just a fixed oken)
     Ok(LoginTemplate {
-        title: "Login",
-        token: "0000", // TODO: implement proper auth
+        title: "API Key",
+        token: settings.publish_key.clone(), 
     })
 }
 
@@ -215,6 +217,7 @@ mod tests {
         let req = test::TestRequest::put()
             .uri("/api/v1/crates/new")
             .set_payload(MY_CRATE_0_1_0)
+            .header("authorization", "00000000-0000-0000-0000-000000000000")
             .to_request();
 
         let _: serde_json::Value = test::read_response_json(&mut app, req).await;
@@ -288,6 +291,7 @@ mod tests {
         let req = test::TestRequest::put()
             .uri("/api/v1/crates/new")
             .set_payload(MY_CRATE_0_1_0)
+            .header("authorization", "00000000-0000-0000-0000-000000000000")
             .to_request();
 
         let _: serde_json::Value = test::read_response_json(&mut app, req).await;

--- a/src/handlers/registry.rs
+++ b/src/handlers/registry.rs
@@ -79,23 +79,21 @@ impl SecureEq for &str {
 fn is_authorized(request: &web::HttpRequest, settings: &Settings) -> Result<(),StatusCode> {
     let publish_key = request.headers().get(header::AUTHORIZATION);
 
-    if let Some(ref key) = settings.publish_key {
-        match publish_key {
-            Some(k) => {
-                let k = match k.to_str() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        return Err(StatusCode::BAD_REQUEST);
-                    }
-                };
-
-                if !key.as_str().secure_eq(&k) {
-                    return Err(StatusCode::FORBIDDEN);
+    match publish_key {
+        Some(k) => {
+            let k = match k.to_str() {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(StatusCode::BAD_REQUEST);
                 }
-            },
-            None => {
-                return Err(StatusCode::UNAUTHORIZED);
+            };
+
+            if !settings.publish_key.as_str().secure_eq(&k) {
+                return Err(StatusCode::FORBIDDEN);
             }
+        },
+        None => {
+            return Err(StatusCode::UNAUTHORIZED);
         }
     }
 
@@ -314,6 +312,7 @@ mod tests {
         let req = test::TestRequest::put()
             .uri("/api/v1/crates/new")
             .set_payload(MY_CRATE_0_1_0)
+            .header("authorization", "00000000-0000-0000-0000-000000000000")
             .to_request();
 
         let resp: serde_json::Value = test::read_response_json(&mut app, req).await;
@@ -338,6 +337,7 @@ mod tests {
         let req = test::TestRequest::put()
             .uri("/api/v1/crates/new")
             .set_payload(MY_CRATE_0_1_0)
+            .header("authorization", "00000000-0000-0000-0000-000000000000")
             .to_request();
 
         let resp: serde_json::Value = test::read_response_json(&mut app, req).await;
@@ -348,6 +348,7 @@ mod tests {
         let req = test::TestRequest::put()
             .uri("/api/v1/crates/new")
             .set_payload(MY_CRATE_0_1_0)
+            .header("authorization", "00000000-0000-0000-0000-000000000000")
             .to_request();
 
         let resp: serde_json::Value = test::read_response_json(&mut app, req).await;
@@ -373,12 +374,14 @@ mod tests {
         let req = test::TestRequest::put()
             .uri("/api/v1/crates/new")
             .set_payload(MY_CRATE_0_1_0)
+            .header("authorization", "00000000-0000-0000-0000-000000000000")
             .to_request();
 
         let _: serde_json::Value = test::read_response_json(&mut app, req).await;
 
         let req = test::TestRequest::delete()
             .uri("/api/v1/crates/my-crate/0.1.0/yank")
+            .header("authorization", "00000000-0000-0000-0000-000000000000")
             .to_request();
 
         let resp: serde_json::Value = test::read_response_json(&mut app, req).await;
@@ -403,18 +406,21 @@ mod tests {
         let req = test::TestRequest::put()
             .uri("/api/v1/crates/new")
             .set_payload(MY_CRATE_0_1_0)
+            .header("authorization", "00000000-0000-0000-0000-000000000000")
             .to_request();
 
         let _: serde_json::Value = test::read_response_json(&mut app, req).await;
 
         let req = test::TestRequest::delete()
             .uri("/api/v1/crates/my-crate/0.1.0/yank")
+            .header("authorization", "00000000-0000-0000-0000-000000000000")
             .to_request();
 
         let _: serde_json::Value = test::read_response_json(&mut app, req).await;
 
         let req = test::TestRequest::put()
             .uri("/api/v1/crates/my-crate/0.1.0/unyank")
+            .header("authorization", "00000000-0000-0000-0000-000000000000")
             .to_request();
 
         let resp: serde_json::Value = test::read_response_json(&mut app, req).await;
@@ -439,6 +445,7 @@ mod tests {
         let req = test::TestRequest::put()
             .uri("/api/v1/crates/new")
             .set_payload(MY_CRATE_0_1_0)
+            .header("authorization", "00000000-0000-0000-0000-000000000000")
             .to_request();
 
         let _: serde_json::Value = test::read_response_json(&mut app, req).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ pub struct Settings {
     pub git_binary: PathBuf,
 
     /// The key that must be presented in order to publish a crate.
-    pub publish_key: Option<String>,
+    pub publish_key: String,
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -28,7 +28,7 @@ pub fn get_test_settings(data_dir: &Path) -> web::Data<Settings> {
         crate_dir: data_dir.join("crates").to_path_buf(),
         index_dir: data_dir.join("index").to_path_buf(),
         git_binary: PathBuf::from("git"),
-        publish_key: None,
+        publish_key: "00000000-0000-0000-0000-000000000000".to_string(),
     };
     web::Data::new(settings)
 }


### PR DESCRIPTION
Hi,

By protecting the /me with basic authentication to not expose the API key to the world (via reverse proxy), you natively limit the publish but keep the get accessible from your cargo.

Here is the code of my dockerfile to generate the container for testing:
```
FROM rust:1-slim-buster as build

WORKDIR /app
ADD . /app/
RUN apt-get update && apt-get install -y libssl-dev pkg-config git
RUN cargo build --release
RUN find /app -iname estuary

FROM rust:1-slim-buster

# Estuary relies on being able to run `git` on the command-line.
# It additionally uses the `git2` crate which indirectly depends on `libssl`.
RUN apt-get update && apt-get install -y \
  git \
  pkg-config libssl-dev \
  && rm -rf /var/lib/apt/lists/*

COPY --from=build /app/target/release/estuary /usr/bin/

# Use a volume to store our service data
VOLUME ["/var/lib/estuary"]

# Configure the service.
#
# These env vars will get the files Estuary needs to write into our volume and
# enable some basic logging HOWEVER you'll still need to configure the
# **base url** based on the public host/port you want to use.
ENV ESTUARY_INDEX_DIR="/var/lib/estuary/index" \
    ESTUARY_CRATE_DIR="/var/lib/estuary/crates" \
    RUST_LOG="actix_web=INFO,estuary=INFO"

EXPOSE 7878

# When running the container, don't forget you'll need to specify the base url
# either via a flag or environment variable.
ENTRYPOINT ["estuary"]
```