### PR TITLE
Set maximum payload size to `10MB`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ async fn main() -> Result<(), EstuaryError> {
         App::new()
             .wrap(middleware::Logger::default())
             .app_data(package_index.clone())
+            .app_data(web::PayloadConfig::new(10 * 1024 * 1024)) // 10MB
             .data(settings.clone())
             .configure(handlers::configure_routes)
     })


### PR DESCRIPTION
This increases the maximum payload size for the entire Actix app to 10MB.

We've hit the size limit while publishing [Eclipse Zenoh 1.0.0-alpha.1](https://crates.io/crates/zenoh/1.0.0-alpha.2):

```text
error: failed to publish to registry at http://localhost:7878
  Caused by:
    failed to get a 200 OK response, got 413
    headers:
        HTTP/1.1 413 Payload Too Large
        content-length: 29
        content-type: text/plain; charset=utf-8
        date: Thu, 20 Jun 2024 13:51:03 GMT
        
    body:
    A payload reached size limit.
```

[For reference crates.io has a maximum upload size of 10MB.](https://github.com/rust-lang/crates.io/blob/main/src/config/server.rs#L185)